### PR TITLE
compilation of the SDK bug fix

### DIFF
--- a/libPS4/include/types.h
+++ b/libPS4/include/types.h
@@ -70,7 +70,7 @@ typedef volatile s64 vs64;
 
 /* POSIX types */
 
-//typedef uint32_t __dev_t;
+typedef uint32_t __dev_t;
 typedef uint32_t blksize_t;
 typedef int64_t  blkcnt_t;
 typedef uint32_t dev_t;


### PR DESCRIPTION
Uncommented the line 73 of "libPS4/include/types.h" to fix a bug during the process of compilation of the SDK.